### PR TITLE
전술대항전 + SLG 오타 수정

### DIFF
--- a/ERB/SHOP/SHOP_LIFE/SHOP_LIFE66_전술대항전/闘技場_本体.ERB
+++ b/ERB/SHOP/SHOP_LIFE/SHOP_LIFE66_전술대항전/闘技場_本体.ERB
@@ -116,7 +116,7 @@ ELSE
 ENDIF
 
 PRINTFORML 「좋아, 그렇다면 이 녀석이 상대다.」
-PRINTFORMW 상대 이름은 %상대이름%이다.
+PRINTFORMW 상대 이름은 %조사처리(상대이름,"다")%.
 PRINTFORML 「죽지만 않는 선에서 마음껏 싸우라고, 흐흐흐.」
 PRINTFORMW %조사처리(ANAME(대상),"는")% 접수처를 빠져 나가, 검투장으로 향했다.
 

--- a/ERB/SLG/SLG_COMBAT.ERB
+++ b/ERB/SLG/SLG_COMBAT.ERB
@@ -264,7 +264,7 @@ IF CITY_SOLDIER:(ARG:2) <= 0
 	CITY_IS_ATTACKED:(ARG:2) = 0
 
 	;도시 점령에 의한 약탈
-	;LOCAL 10:그 도시에 비축되혀 있던 재산
+	;LOCAL 10:그 도시에 비축되어 있던 재산
 	;무소속의 도시는 경제 규모의 30%를 비축하고 있으면 간주한다
 	IF LOCAL:6 > 0
 		LOCAL:10 = MONEY:(LOCAL:6) * CITY_ECONOMY:(ARG:2) / GET_SUM_ECONOMY(LOCAL:6)
@@ -1126,7 +1126,7 @@ SELECTCASE IFRAND("0, 1", 1, "2", TINT >= ABL_POWER(50, -1), "3", TINT >= ABL_PO
 		BATTLE_RATE_ATC:(ARG:0) += 50
 		BATTLE_RATE_GRD:(ARG:0) += 25
 	CASE 2
-		PRINTFORML %BATTLE_NAME:(ARG:0)%군은 %BATTLE_NAME:(ARG:1)%군이 병력을 넓게 전개시킨 틍을 타 각개 격파 했다
+		PRINTFORML %BATTLE_NAME:(ARG:0)%군은 %BATTLE_NAME:(ARG:1)%군이 병력을 넓게 전개시킨 틈을 타 각개 격파 했다
 		BATTLE_RATE_DMG:(ARG:0) += 0
 		BATTLE_RATE_ATC:(ARG:0) += 60
 		BATTLE_RATE_GRD:(ARG:0) += 30


### PR DESCRIPTION
전술대항전 조사처리 "다" 유효함 확인
카린일땐 "이다"뜨고 아이리는 "다"로 뜸
오늘은 이걸로 끝
![조사처리 _다_ 정상작동1](https://github.com/DarrnB/eraBAK-/assets/56868275/c4055a44-7e65-4b38-8c79-b0f35ea46345)
![조사처리 _다_ 정상작동2](https://github.com/DarrnB/eraBAK-/assets/56868275/021c8d8d-1923-4b8b-a988-980912ff492f)
